### PR TITLE
Update Macao to Macao, China

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ var countries = {
   'LI': 'Liechtenstein',
   'LT': 'Lithuania',
   'LU': 'Luxembourg',
-  'MO': 'Macao',
+  'MO': 'Macao, China',
   'MK': 'Macedonia, the Former Yugoslav Republic of',
   'MG': 'Madagascar',
   'MW': 'Malawi',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ti-countries",
   "description": "TI Country List",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "TI",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Updates "Macao" to "Macao, China" and updates version.